### PR TITLE
Add Bluetooth service skeleton, client library and unit tests

### DIFF
--- a/BtClientLibrary/BluetoothServiceClient.cs
+++ b/BtClientLibrary/BluetoothServiceClient.cs
@@ -1,0 +1,50 @@
+using System.Net.WebSockets;
+using System.Net.Http.Json;
+using System.Text;
+using BtClientLibrary.Models;
+
+namespace BtClientLibrary;
+
+public class BluetoothServiceClient
+{
+    private readonly HttpClient _httpClient;
+    private ClientWebSocket? _webSocket;
+
+    public event EventHandler<string>? StreamReceived;
+
+    public BluetoothServiceClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<IEnumerable<BluetoothDevice>> ScanAsync(CancellationToken cancellationToken = default)
+    {
+        var devices = await _httpClient.GetFromJsonAsync<IEnumerable<BluetoothDevice>>("/bluetooth/scan", cancellationToken);
+        return devices ?? Enumerable.Empty<BluetoothDevice>();
+    }
+
+    public async Task ConnectStreamAsync(Uri uri, CancellationToken cancellationToken = default)
+    {
+        _webSocket = new ClientWebSocket();
+        await _webSocket.ConnectAsync(uri, cancellationToken);
+        _ = ReceiveLoop(_webSocket, cancellationToken);
+    }
+
+    private async Task ReceiveLoop(ClientWebSocket socket, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[1024];
+        while (socket.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
+        {
+            var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationToken);
+            }
+            else
+            {
+                var message = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                StreamReceived?.Invoke(this, message);
+            }
+        }
+    }
+}

--- a/BtClientLibrary/BtClientLibrary.csproj
+++ b/BtClientLibrary/BtClientLibrary.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/BtClientLibrary/Models/BluetoothDevice.cs
+++ b/BtClientLibrary/Models/BluetoothDevice.cs
@@ -1,0 +1,3 @@
+namespace BtClientLibrary.Models;
+
+public record BluetoothDevice(string Name, string Address);

--- a/BtService.Tests/BluetoothManagerTests.cs
+++ b/BtService.Tests/BluetoothManagerTests.cs
@@ -1,0 +1,21 @@
+using BtService.Models;
+using BtService.Services;
+using Microsoft.Extensions.Logging;
+
+namespace BtService.Tests;
+
+public class BluetoothManagerTests
+{
+    [Fact]
+    public async Task ScanAsync_ReturnsDevicesFromAllClients()
+    {
+        var logger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger<BluetoothManager>();
+        var clients = new IBluetoothClient[] { new BleClient(), new ClassicClient() };
+        var manager = new BluetoothManager(clients, logger);
+
+        var devices = (await manager.ScanAsync()).ToList();
+
+        Assert.Contains(devices, d => d.Name == "BleDevice");
+        Assert.Contains(devices, d => d.Name == "ClassicDevice");
+    }
+}

--- a/BtService.Tests/BluetoothServiceClientTests.cs
+++ b/BtService.Tests/BluetoothServiceClientTests.cs
@@ -1,0 +1,35 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using BtClientLibrary;
+using BtClientLibrary.Models;
+
+namespace BtService.Tests;
+
+public class BluetoothServiceClientTests
+{
+    [Fact]
+    public async Task ScanAsync_ParsesDevices()
+    {
+        var handler = new FakeHandler();
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+        var client = new BluetoothServiceClient(httpClient);
+
+        handler.Response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new [] { new BluetoothDevice("A", "1") })
+        };
+
+        var devices = await client.ScanAsync();
+
+        Assert.Single(devices);
+        Assert.Equal("A", devices.First().Name);
+    }
+
+    private class FakeHandler : HttpMessageHandler
+    {
+        public HttpResponseMessage? Response { get; set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(Response ?? new HttpResponseMessage(HttpStatusCode.NotFound));
+    }
+}

--- a/BtService.Tests/BtService.Tests.csproj
+++ b/BtService.Tests/BtService.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../BtService/BtService.csproj" />
+    <ProjectReference Include="../BtClientLibrary/BtClientLibrary.csproj" />
+  </ItemGroup>
+</Project>

--- a/BtService/BtService.csproj
+++ b/BtService/BtService.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/BtService/Models/BluetoothDevice.cs
+++ b/BtService/Models/BluetoothDevice.cs
@@ -1,0 +1,3 @@
+namespace BtService.Models;
+
+public record BluetoothDevice(string Name, string Address);

--- a/BtService/Program.cs
+++ b/BtService/Program.cs
@@ -1,0 +1,47 @@
+using BtService.Models;
+using BtService.Services;
+using System.Net.WebSockets;
+using System.Text;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Configuration is loaded from appsettings.json, environment variables and command line by default
+builder.Services.AddSingleton<IBluetoothClient, BleClient>();
+builder.Services.AddSingleton<IBluetoothClient, ClassicClient>();
+builder.Services.AddSingleton<BluetoothManager>();
+
+builder.Services.AddLogging();
+
+var app = builder.Build();
+
+app.MapGet("/bluetooth/scan", async (BluetoothManager manager) => await manager.ScanAsync());
+app.MapGet("/bluetooth/status", (BluetoothManager manager) => new { status = manager.GetStatus() });
+
+app.MapGet("/", () => Results.Content("""
+<!DOCTYPE html>
+<html>
+<head>
+ <title>Bluetooth Manager</title>
+ <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css\" />
+</head>
+<body class=\"p-3\">
+ <h1>Bluetooth Manager</h1>
+ <p>Simple web interface placeholder.</p>
+</body>
+</html>
+""", "text/html"));
+
+app.MapGet("/ws/stream", async (HttpContext context, BluetoothManager manager) =>
+{
+    if (context.WebSockets.IsWebSocketRequest)
+    {
+        using var socket = await context.WebSockets.AcceptWebSocketAsync();
+        await manager.HandleWebSocketAsync(socket);
+    }
+    else
+    {
+        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+    }
+});
+
+app.Run();

--- a/BtService/Services/BleClient.cs
+++ b/BtService/Services/BleClient.cs
@@ -1,0 +1,15 @@
+using BtService.Models;
+
+namespace BtService.Services;
+
+public class BleClient : IBluetoothClient
+{
+    public Task<IEnumerable<BluetoothDevice>> ScanAsync(CancellationToken cancellationToken = default)
+    {
+        var devices = new List<BluetoothDevice>
+        {
+            new("BleDevice", "00:11:22:33:44:55")
+        };
+        return Task.FromResult<IEnumerable<BluetoothDevice>>(devices);
+    }
+}

--- a/BtService/Services/BluetoothManager.cs
+++ b/BtService/Services/BluetoothManager.cs
@@ -1,0 +1,51 @@
+using BtService.Models;
+using System.Net.WebSockets;
+using System.Text;
+
+namespace BtService.Services;
+
+public class BluetoothManager
+{
+    private readonly IEnumerable<IBluetoothClient> _clients;
+    private readonly ILogger<BluetoothManager> _logger;
+
+    public BluetoothManager(IEnumerable<IBluetoothClient> clients, ILogger<BluetoothManager> logger)
+    {
+        _clients = clients;
+        _logger = logger;
+    }
+
+    public async Task<IEnumerable<BluetoothDevice>> ScanAsync(CancellationToken cancellationToken = default)
+    {
+        var devices = new List<BluetoothDevice>();
+        foreach (var client in _clients)
+        {
+            devices.AddRange(await client.ScanAsync(cancellationToken));
+        }
+        return devices;
+    }
+
+    public string GetStatus() => "running";
+
+    public async Task HandleWebSocketAsync(WebSocket socket, CancellationToken cancellationToken = default)
+    {
+        var message = Encoding.UTF8.GetBytes("{\"status\":\"connected\"}");
+        var segment = new ArraySegment<byte>(message);
+        await socket.SendAsync(segment, WebSocketMessageType.Text, true, cancellationToken);
+        // simple echo loop
+        var buffer = new byte[1024 * 4];
+        while (socket.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
+        {
+            var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancellationToken);
+            }
+            else
+            {
+                var msg = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                _logger.LogInformation("WS message: {Message}", msg);
+            }
+        }
+    }
+}

--- a/BtService/Services/ClassicClient.cs
+++ b/BtService/Services/ClassicClient.cs
@@ -1,0 +1,15 @@
+using BtService.Models;
+
+namespace BtService.Services;
+
+public class ClassicClient : IBluetoothClient
+{
+    public Task<IEnumerable<BluetoothDevice>> ScanAsync(CancellationToken cancellationToken = default)
+    {
+        var devices = new List<BluetoothDevice>
+        {
+            new("ClassicDevice", "AA:BB:CC:DD:EE:FF")
+        };
+        return Task.FromResult<IEnumerable<BluetoothDevice>>(devices);
+    }
+}

--- a/BtService/Services/IBluetoothClient.cs
+++ b/BtService/Services/IBluetoothClient.cs
@@ -1,0 +1,8 @@
+using BtService.Models;
+
+namespace BtService.Services;
+
+public interface IBluetoothClient
+{
+    Task<IEnumerable<BluetoothDevice>> ScanAsync(CancellationToken cancellationToken = default);
+}

--- a/BtService/appsettings.json
+++ b/BtService/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Scaffold Bluetooth service hosting REST and WebSocket endpoints with DI and logging
- Add client library wrapping HTTP and WebSocket interactions
- Introduce unit tests for manager and client components

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b04cca5c8323bcb70da7ebe62455