### PR TITLE
Expand Bluetooth client interface with additional operations

### DIFF
--- a/BtService/Models/BluetoothService.cs
+++ b/BtService/Models/BluetoothService.cs
@@ -1,0 +1,7 @@
+namespace BtService.Models;
+
+/// <summary>
+/// Represents a bluetooth service provided by a device.
+/// </summary>
+public record BluetoothService(string Name);
+

--- a/BtService/Services/BleClient.cs
+++ b/BtService/Services/BleClient.cs
@@ -4,7 +4,12 @@ namespace BtService.Services;
 
 public class BleClient : IBluetoothClient
 {
-    public Task<IEnumerable<BluetoothDevice>> ScanAsync(CancellationToken cancellationToken = default)
+    public event EventHandler<bool>? ConnectionStateChanged;
+    public event EventHandler<byte[]>? DataReceived;
+
+    public bool IsConnected { get; private set; }
+
+    public Task<IEnumerable<BluetoothDevice>> Scan(CancellationToken cancellationToken = default)
     {
         var devices = new List<BluetoothDevice>
         {
@@ -12,4 +17,41 @@ public class BleClient : IBluetoothClient
         };
         return Task.FromResult<IEnumerable<BluetoothDevice>>(devices);
     }
+
+    public Task Connect(BluetoothDevice device, CancellationToken cancellationToken = default)
+    {
+        IsConnected = true;
+        ConnectionStateChanged?.Invoke(this, IsConnected);
+        return Task.CompletedTask;
+    }
+
+    public Task Disconnect(CancellationToken cancellationToken = default)
+    {
+        IsConnected = false;
+        ConnectionStateChanged?.Invoke(this, IsConnected);
+        return Task.CompletedTask;
+    }
+
+    public Task<byte[]> Read(CancellationToken cancellationToken = default)
+    {
+        var data = Array.Empty<byte>();
+        DataReceived?.Invoke(this, data);
+        return Task.FromResult(data);
+    }
+
+    public Task Write(byte[] data, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task<IEnumerable<BluetoothService>> GetServices(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult<IEnumerable<BluetoothService>>(new List<BluetoothService>());
+    }
+
+    public Task StartStream(CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
 }
+

--- a/BtService/Services/BluetoothManager.cs
+++ b/BtService/Services/BluetoothManager.cs
@@ -20,7 +20,7 @@ public class BluetoothManager
         var devices = new List<BluetoothDevice>();
         foreach (var client in _clients)
         {
-            devices.AddRange(await client.ScanAsync(cancellationToken));
+            devices.AddRange(await client.Scan(cancellationToken));
         }
         return devices;
     }

--- a/BtService/Services/ClassicClient.cs
+++ b/BtService/Services/ClassicClient.cs
@@ -4,7 +4,12 @@ namespace BtService.Services;
 
 public class ClassicClient : IBluetoothClient
 {
-    public Task<IEnumerable<BluetoothDevice>> ScanAsync(CancellationToken cancellationToken = default)
+    public event EventHandler<bool>? ConnectionStateChanged;
+    public event EventHandler<byte[]>? DataReceived;
+
+    public bool IsConnected { get; private set; }
+
+    public Task<IEnumerable<BluetoothDevice>> Scan(CancellationToken cancellationToken = default)
     {
         var devices = new List<BluetoothDevice>
         {
@@ -12,4 +17,41 @@ public class ClassicClient : IBluetoothClient
         };
         return Task.FromResult<IEnumerable<BluetoothDevice>>(devices);
     }
+
+    public Task Connect(BluetoothDevice device, CancellationToken cancellationToken = default)
+    {
+        IsConnected = true;
+        ConnectionStateChanged?.Invoke(this, IsConnected);
+        return Task.CompletedTask;
+    }
+
+    public Task Disconnect(CancellationToken cancellationToken = default)
+    {
+        IsConnected = false;
+        ConnectionStateChanged?.Invoke(this, IsConnected);
+        return Task.CompletedTask;
+    }
+
+    public Task<byte[]> Read(CancellationToken cancellationToken = default)
+    {
+        var data = Array.Empty<byte>();
+        DataReceived?.Invoke(this, data);
+        return Task.FromResult(data);
+    }
+
+    public Task Write(byte[] data, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task<IEnumerable<BluetoothService>> GetServices(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult<IEnumerable<BluetoothService>>(new List<BluetoothService>());
+    }
+
+    public Task StartStream(CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
 }
+

--- a/BtService/Services/IBluetoothClient.cs
+++ b/BtService/Services/IBluetoothClient.cs
@@ -2,7 +2,58 @@ using BtService.Models;
 
 namespace BtService.Services;
 
+/// <summary>
+/// Defines the operations required by a bluetooth client implementation.
+/// </summary>
 public interface IBluetoothClient
 {
-    Task<IEnumerable<BluetoothDevice>> ScanAsync(CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Occurs when the connection state changes.
+    /// </summary>
+    event EventHandler<bool>? ConnectionStateChanged;
+
+    /// <summary>
+    /// Occurs when data is received from the device.
+    /// </summary>
+    event EventHandler<byte[]>? DataReceived;
+
+    /// <summary>
+    /// Indicates whether the client is currently connected to a device.
+    /// </summary>
+    bool IsConnected { get; }
+
+    /// <summary>
+    /// Scans for available bluetooth devices.
+    /// </summary>
+    Task<IEnumerable<BluetoothDevice>> Scan(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Connects to the specified bluetooth device.
+    /// </summary>
+    Task Connect(BluetoothDevice device, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Disconnects from the currently connected device.
+    /// </summary>
+    Task Disconnect(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads data from the connected device.
+    /// </summary>
+    Task<byte[]> Read(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Writes data to the connected device.
+    /// </summary>
+    Task Write(byte[] data, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the services exposed by the connected device.
+    /// </summary>
+    Task<IEnumerable<BluetoothService>> GetServices(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Starts streaming data from the connected device.
+    /// </summary>
+    Task StartStream(CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- expand `IBluetoothClient` with connection events, stream operations and IO methods
- add stub implementations for new interface members in BLE and Classic clients
- introduce `BluetoothService` record for service discovery

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b563d3ec8323a5e9a81b61847522